### PR TITLE
Scan entire project directory

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,6 +2,7 @@
 import { NgModule } from '@angular/core';
 import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 import { authGuard } from './guards/auth.guard';
+import { adminGuard } from './guards/admin.guard';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
@@ -46,7 +47,7 @@ export const routes: Routes = [
     path: 'admin',
     loadComponent: () =>
       import('./pages/admin/admin-layout/admin-layout.component').then(m => m.AdminLayoutComponent),
-    canActivate: [authGuard],
+    canActivate: [authGuard, adminGuard], // ✅ Both authentication AND authorization check
     children: [
       {
         path: '',
@@ -73,7 +74,12 @@ export const routes: Routes = [
 
   // Optional: keep a single alias for old deep links to /van-report/:id
   // This simply forwards to the canonical admin route.
-  { path: 'van-report/:id', redirectTo: 'admin/van-report/:id', pathMatch: 'full' },
+  { 
+    path: 'van-report/:id', 
+    redirectTo: 'admin/van-report/:id', 
+    pathMatch: 'full',
+    canActivate: [authGuard, adminGuard] // ✅ Protect the alias route too
+  },
 
   // Catch-all
   { path: '**', redirectTo: 'login' },

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,0 +1,48 @@
+// src/app/guards/admin.guard.ts
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+import { map, take } from 'rxjs/operators';
+
+/**
+ * Admin Guard - Verifies user has admin or owner role
+ * This guard should be used AFTER authGuard to ensure user is both:
+ * 1. Authenticated (checked by authGuard)
+ * 2. Has admin privileges (checked by this guard)
+ */
+export const adminGuard: CanActivateFn = (route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  return authService.currentUserProfile$.pipe(
+    take(1),
+    map(userProfile => {
+      console.log('[adminGuard] attempting:', state.url, 'user roles:', userProfile?.roles ?? 'no profile');
+      
+      // If no user profile, redirect to login
+      if (!userProfile) {
+        console.warn('[adminGuard] no user profile → redirecting to /login');
+        return router.createUrlTree(['/login'], {
+          queryParams: { redirectTo: state.url }
+        });
+      }
+
+      // Check if user has admin or owner role
+      const hasAdminAccess = userProfile.roles.includes('admin') || userProfile.roles.includes('owner');
+      
+      if (hasAdminAccess) {
+        console.log('[adminGuard] user has admin access → allowing');
+        return true;
+      }
+
+      // User doesn't have admin privileges - redirect to driver area
+      console.warn('[adminGuard] user lacks admin privileges → redirecting to /van-selection');
+      return router.createUrlTree(['/van-selection'], {
+        queryParams: { 
+          error: 'admin_access_denied',
+          message: 'You do not have admin privileges'
+        }
+      });
+    })
+  );
+};


### PR DESCRIPTION
Add `adminGuard` to enforce role-based access control for admin routes, preventing unauthorized access.

This PR addresses a critical security vulnerability where admin routes were only protected by authentication, allowing any logged-in user (e.g., a driver) to access admin pages. The new `adminGuard` verifies that a user has either an 'admin' or 'owner' role before granting access to `/admin` routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3cdfa9f-caf6-4c65-8aba-192c4ab6c2e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3cdfa9f-caf6-4c65-8aba-192c4ab6c2e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

